### PR TITLE
feat(Debounce Service): support invokeApply parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ angular.module('myApp', ['debounce']);
 
 ## Service Usage
 
-`debounce(func, wait, [immediate])`
+`debounce(func, wait, [immediate], [invokeApply])`
 
 ### Arguments
 
@@ -39,6 +39,7 @@ angular.module('myApp', ['debounce']);
 |func|function|The function we want to **debounce**|
 |wait|number|Number of miliseconds to **wait** before invoking the debounced function|
 |immediate (optional)|boolean|Pass `true` for the **immediate** parameter to cause **debounce** to trigger the function on the leading instead of the trailing edge of the **wait** interval. Useful in circumstances like preventing accidental double-clicks on a "submit" button from firing a second time.|
+|invokeApply (optional)|boolean|`invokeApply` param passed to `$timeout` service (defines whether apply should be called in order to trigger a digest cycle at the end of the `func` call) - see [$timeout](https://docs.angularjs.org/api/ng/service/$timeout) service for more details|
 
 ### Returns
 

--- a/angular-debounce.js
+++ b/angular-debounce.js
@@ -2,7 +2,7 @@
 
 angular.module('debounce', [])
   .service('debounce', ['$timeout', function ($timeout) {
-    return function (func, wait, immediate) {
+    return function (func, wait, immediate, invokeApply) {
       var timeout, args, context, result;
       function debounce() {
         /* jshint validthis:true */
@@ -18,7 +18,7 @@ angular.module('debounce', [])
         if (timeout) {
           $timeout.cancel(timeout);
         }
-        timeout = $timeout(later, wait);
+        timeout = $timeout(later, wait, invokeApply);
         if (callNow) {
           result = func.apply(context, args);
         }

--- a/test/angular-debounce.js
+++ b/test/angular-debounce.js
@@ -94,6 +94,37 @@ describe('unit testing angular debounce service', function () {
   });
 });
 
+describe('Calling $timeout with invokeApply', function () {
+  var mocks = {};
+  var $timeout, debounce;
+
+  angular.module('TimeoutMockModule', []).factory('$timeout', function(){
+    $timeout = jasmine.createSpy();
+    $timeout.cancel = jasmine.createSpy();
+    mocks.$timeout = $timeout;
+    return $timeout;
+  });
+
+  beforeEach(module('debounce', 'TimeoutMockModule'));
+  beforeEach(inject(function (_debounce_, _$timeout_) {
+    debounce = _debounce_;
+    $timeout = _$timeout_;
+  }));
+
+  it('should support calling $timeout with correct invokeApply parameter', function () {
+    var func = function () {};
+    var debounced = debounce(func, 100, false, true);
+    debounced();
+    expect(mocks.$timeout).toHaveBeenCalledWith(jasmine.any(Function), 100, true);
+    debounced = debounce(func, 100, false, false);
+    debounced();
+    expect(mocks.$timeout).toHaveBeenCalledWith(jasmine.any(Function), 100, false);
+    debounced = debounce(func, 100);
+    debounced();
+    expect(mocks.$timeout).toHaveBeenCalledWith(jasmine.any(Function), 100, undefined);
+  });
+});
+
 describe('unit testing angular debounce directive', function () {
   var $compile, $rootScope, element, defer, debounce;
 
@@ -171,7 +202,7 @@ describe('unit testing angular debounce directive', function () {
   });
 
   it('should live well with other parsers', function () {
-    element = $compile('<input type="checkbox" ng-model="blah" debounce="100" ng-true-value="YES" ng-false-value="NO"></input>')($rootScope);
+    element = $compile('<input type="checkbox" ng-model="blah" debounce="100" ng-true-value="\'YES\'" ng-false-value="\'NO\'"></input>')($rootScope);
     $rootScope.blah = 'YES';
     $rootScope.$digest();
     element.click();


### PR DESCRIPTION
Add invokeApply parameter to the debounce service in order to be able to use debounce without $rootScope.$apply(); call at the end of the function execution.
The parameter is passed as is to $timeout service.