### PR TITLE
Add promise gesture

### DIFF
--- a/angular-debounce.js
+++ b/angular-debounce.js
@@ -12,11 +12,11 @@ angular.module('debounce', [])
           timeout = null;
           if (!immediate) {
             if(!funcInRunning){						
-  						funcInRunning = sync;						
-  						result = func.apply(context, args);
-  					} else {
-  						timeout = $timeout(later, wait, invokeApply);
-  					}
+  		funcInRunning = sync;						
+  		result = func.apply(context, args);
+  	    } else {
+  		timeout = $timeout(later, wait, invokeApply);
+  	    }
           }
         };
         var callNow = immediate && !timeout && !funcInRunning;

--- a/angular-debounce.js
+++ b/angular-debounce.js
@@ -2,8 +2,8 @@
 
 angular.module('debounce', [])
   .service('debounce', ['$timeout', function ($timeout) {
-    return function (func, wait, immediate, invokeApply) {
-      var timeout, args, context, result;
+    return function (func, wait, immediate, invokeApply, sync) {
+      var timeout, args, context, result, funcInRunning;
       function debounce() {
         /* jshint validthis:true */
         context = this;
@@ -11,15 +11,21 @@ angular.module('debounce', [])
         var later = function () {
           timeout = null;
           if (!immediate) {
-            result = func.apply(context, args);
+            if(!funcInRunning){						
+  						funcInRunning = sync;						
+  						result = func.apply(context, args);
+  					} else {
+  						timeout = $timeout(later, wait, invokeApply);
+  					}
           }
         };
-        var callNow = immediate && !timeout;
+        var callNow = immediate && !timeout && !funcInRunning;
         if (timeout) {
           $timeout.cancel(timeout);
         }
         timeout = $timeout(later, wait, invokeApply);
         if (callNow) {
+          funcInRunning = sync;
           result = func.apply(context, args);
         }
         return result;
@@ -28,6 +34,9 @@ angular.module('debounce', [])
         $timeout.cancel(timeout);
         timeout = null;
       };
+      debounce.endPromise = function() {
+			funcInRunning = false;
+		  };
       return debounce;
     };
   }])


### PR DESCRIPTION
Suppose that the "func" has inside it a promise.
Like this example: 

    var debounceUpdateEntity = debounce(function(entity) {
		$http.put('/resource/entity/entity.id, entity, {
		}).then(function(response) {
			entity.version = response.data.version;
		}, function() {
		})['finally'](function() {
			debounceUpdateEntity.endPromise();
		});
	}, waitDebouceTime, false, true, true);

I would that until the promise not have finish his work, the debounce func was not called

For you this is correct?